### PR TITLE
fix(mix.exs): add parentheses to variables to remove ambiguity

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,9 +5,9 @@ defmodule Changex.Mixfile do
     [app: :changex,
      version: "0.1.1",
      elixir: "~> 1.0",
-     description: description,
-     package: package,
-     deps: deps]
+     description: description(),
+     package: package(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
The mix variables `description` `package` and `deps` were all throwing
a warning in Elixir 1.4 because the names were ambiguous. The solution
is to add parentheses to the variable names which will then suppress
the warning.